### PR TITLE
Add version

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,7 +1,6 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import ssl
 
-
 # CTAP1/U2F requires serving over https
 https = True
 
@@ -15,8 +14,6 @@ if https:
 else:
     host =('localhost' , 8080)
     httpd = HTTPServer(('localhost', 8080), SimpleHTTPRequestHandler)
-
-
 
 print('serving on ', host)
 httpd.serve_forever()

--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
 		Solo Genuine
 	  </h1>
 	  <h3 id="useragent" style="color:gray;"></h3>
-	  <h3 id="success" style="color:green;"></h3>
+      <h3 id="success" style="color:green;"></h3>
+      <h3 id="success-version" style="color:green;"></h3>
 	  <h3 id="errors" style="color:red;"></h3>
 	  <h3 id="fingerprint" style="color:gray;"></h3>
 	  <h3 id="debug" style="color:purple;"></h3>

--- a/js/ctap1.js
+++ b/js/ctap1.js
@@ -2,7 +2,7 @@ function parse_device_response(arr)
 {
     var dataview = new DataView(arr.slice(1,5).buffer);
 
-    count = dataview.getUint32(0, true); // get count as 32 bit LE integer
+    count = dataview.getUint32(0, false); // get count as 32 bit BE integer
 
     data = null;
     if (arr[5] == 0) {

--- a/js/genuine.js
+++ b/js/genuine.js
@@ -52,9 +52,6 @@ async function check_version(){
         s = 'Here are some secure random bytes from Solo: ' + array2hex(rng.data);
         document.getElementById('fingerprint').textContent = s;
     }
-
-
-
 }
 
 function check() {

--- a/js/genuine.js
+++ b/js/genuine.js
@@ -1,5 +1,6 @@
 function prepare_genuine() {
     document.getElementById('success').textContent = '';
+    document.getElementById('success-version').textContent = '';
     document.getElementById('errors').textContent = '';
     document.getElementById('debug').textContent = '';
     document.getElementById('useragent').textContent = platform.description;
@@ -17,6 +18,43 @@ function prepare_genuine() {
     } else {
         document.getElementById('success').textContent += 'Your browser supports WebAuthn';
     }
+}
+
+async function check_version(){
+    document.getElementById('errors').textContent = 'Checking firmware version, please wait...';
+    document.getElementById('success-version').textContent = '';
+    version = await get_version();
+    console.log(version);
+        document.getElementById('errors').textContent = '';
+    if (version.errorCode)
+    {
+        document.getElementById('errors').textContent = 'Your firmware is out of date.  Please update.';
+    }
+    else if (version.status != 'CTAP1_SUCCESS')
+    {
+        document.getElementById('errors').textContent = 'Error: ' + version.status;
+    }
+    else
+    {
+        s = version.data[0] + '.' + version.data[1]
+        if (version.data[0] == 1 && version.data[1] == 0)
+        {
+            document.getElementById('success-version').textContent = 'Firmware is up to date: ' + s + '.';
+        }
+        else
+        {
+            document.getElementById('success').textContent += '.  Version: ' + s;
+            document.getElementById('errors').textContent = 'Your firmware is out of date.  Please update.';
+        }
+
+        rng = await get_rng();
+        console.log(rng);
+        s = 'Here are some secure random bytes from Solo: ' + array2hex(rng.data);
+        document.getElementById('fingerprint').textContent = s;
+    }
+
+
+
 }
 
 function check() {
@@ -99,6 +137,9 @@ function check() {
             console.log("UNKNOWN ATTESTATION");
             document.getElementById('errors').textContent = 'unknown key';
         }
+
+        check_version();
+
     })
     .catch(e => {
         console.log(e);

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -37,6 +37,10 @@ function hex2array(string)
     return arr;
 }
 
+function array2hex(buffer) {
+  return Array.prototype.map.call(new Uint8Array(buffer), x => ('00' + x.toString(16)).slice(-2)).join('');
+}
+
 function websafe64(base64) {
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }

--- a/js/update.js
+++ b/js/update.js
@@ -1,10 +1,18 @@
-var get_rng = function(func) {
+var get_rng = wrap_promise(function(func) {
     var req = encode_ctap1_request_as_keyhandle(CMD.rng, 0, 0,);
     send_msg_u2f(req, function(resp){
         // if (func) func(resp);
         console.log('RNG RESP:', resp);
     });
-}
+})
+
+var get_version = wrap_promise(function(func) {
+    var req = encode_ctap1_request_as_keyhandle(CMD.version);
+    send_msg_u2f(req, function(resp){
+        if (func) func(resp);
+        // console.log('VERSION RESP:', resp);
+    });
+})
 
 var get_boot_version_ = function(func) {
     var req = encode_ctap1_request_as_keyhandle(CMD.boot_version);

--- a/make_localhost_cert.sh
+++ b/make_localhost_cert.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -xe
+
+# Run this to make cert you can import in chrome, then run localhost with HTTPS
+
+ openssl req -x509 -out localhost.crt -keyout localhost.key   -newkey rsa:2048 -nodes -sha256   -subj '/CN=localhost' -extensions EXT -config <( \
+   printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")


### PR DESCRIPTION
Adds support for checking the firmware version when you click Check.  Old/current Solo devices don't support the command to check the version, so it'll trigger a U2F auth request and timeout.  This is detected as out of date.

Also pulls some random bytes from Solo if it's up to date.